### PR TITLE
destroy-page-create

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,5 +12,6 @@
 @import "new_item";
 @import "change_item";
 @import "buy_item";
+@import "cut_item";
 @import "users_registration";
 @import "users"

--- a/app/assets/stylesheets/cut_item.scss
+++ b/app/assets/stylesheets/cut_item.scss
@@ -1,0 +1,115 @@
+.single__header{
+  width: auto;
+  text-align: center;
+  height: 128px;
+  background-color: whitesmoke;
+  .single__logo{
+    display: inline-block;
+    margin: 40px 0 0;
+    width: 180px;
+    height: 50px;
+    background-image: url(/assets/logo.png);
+    background-size: cover;
+  }
+}
+.single__main{
+  width: auto;
+  background-color: whitesmoke;
+  .single__container{
+    max-width: 700px;
+    margin: auto;
+    background-color: #fff;
+    .sell__destroy{
+      height: 180px;
+      width: auto;
+      border: solid 3px #eee;
+      .sell__item--destyoy-check{
+        font-size: 25px;
+        font-weight: bold;
+        text-align: center;
+      }
+      .sell__item--destyoy-notification{
+        font-size: 20px;
+        color:#333;
+        text-align: center;
+      }
+      .sell__item--destyoy-Confirmation{
+        font-size: 20px;
+        color:#333;
+        text-align: center;
+      }
+      .btn__list{
+        display: flex;
+        color: #fff;
+        margin-top: 30px;
+        text-align: center;
+        justify-content: center;
+        .cancel__btn{
+          width: 100px;
+          height: 30px;
+          background-color: lightcyan;
+          border-radius: 4px;
+          margin-right: 15px;
+          text-decoration: none;
+        }
+        .destroy__btn{
+          width: 100px;
+          height: 30px;
+          background-color: lightpink;
+          border-radius: 4px;
+          margin-left: 15px;
+          text-decoration: none;
+        }
+      }
+    }
+
+  }
+}
+.single__footer{
+  width: auto;
+  box-sizing: border-box;
+  height: 220px;
+  background-color:whitesmoke;
+  .footer__list{
+    display: flex;
+    justify-content: center;
+    width: 500px;
+    height: 50px;
+    margin: auto;
+    padding-top: 40px;
+    font-size: 10px;
+    color: #333;
+    .privacy__policy{
+      margin-right: 40px;
+    }
+    .terms__service{
+      margin-right: 40px;
+    }
+    .specific__commerce{
+    }
+  }
+  .apprication__logo{
+    margin: auto;
+    padding-top: 30px;  
+    height: 15px;
+    width: 165px;
+    background-image: url(/assets/logo-white.png);
+    background-size: cover;
+    text-align: center;
+  }
+  .logo__company{
+    display: flex;
+    margin: auto;
+    margin-top: 15px;  
+    width: 100px;
+    
+   .logo__cmark{
+    font-size: 20px;
+    }
+    .logo__app--mark{
+    margin-left: 5px;
+    margin-top: 2px;
+    font-size: 15px;
+    }
+  }
+}

--- a/app/assets/stylesheets/cut_item.scss
+++ b/app/assets/stylesheets/cut_item.scss
@@ -8,7 +8,7 @@
     margin: 40px 0 0;
     width: 180px;
     height: 50px;
-    background-image: url(/assets/logo.png);
+    background-image: url(/assets/logo/logo.png);
     background-size: cover;
   }
 }
@@ -93,7 +93,7 @@
     padding-top: 30px;  
     height: 15px;
     width: 165px;
-    background-image: url(/assets/logo-white.png);
+    background-image: url(/assets/logo/logo-white.png);
     background-size: cover;
     text-align: center;
   }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,6 +33,11 @@ class ItemsController < ApplicationController
     
   end
 
+  #商品削除（仮）
+  def cut
+
+  end
+
   # GET /items/1/edit
   def edit
     # @item = Item.find(params[:id]

--- a/app/views/items/cut.html.haml
+++ b/app/views/items/cut.html.haml
@@ -1,0 +1,32 @@
+.single__header
+  .single__logo
+.single__main
+  .single__container
+    .sell__destroy
+      .sell__item--destyoy-check
+        確認
+      .sell__item--destyoy-notification
+        削除すると二度と復活できません。
+      .sell__item--destyoy-Confirmation
+        本当に削除しますか？
+      .btn__list
+        .cancel__btn
+          = link_to "#" do
+            キャンセル
+        .destroy__btn
+          = link_to "#" do
+            削除
+.single__footer
+  .footer__list
+    .privacy__policy
+      プライバシーポリシー
+    .terms__service
+      FURIMA利用規約
+    .specific__commerce
+      特定商取引に関する表記
+  .apprication__logo
+  .logo__company
+    .logo__cmark
+      ©️
+    .logo__app--mark
+      FURIMA

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       get "buy"
       get "item_details"
       get "change"
+      get "cut"
     end
   end
   resources :brands


### PR DESCRIPTION
[what]
商品削除ページの実装

[why]
一旦取り下げたい際や、間違えて出品した場合、また出品をやめたい場合などに必要なため。誤って削除ページへ遷移した際のため、キャンセルボタンも追加。