### PR TITLE
商品詳細画面画像表示変更

### DIFF
--- a/app/assets/stylesheets/item_details.scss
+++ b/app/assets/stylesheets/item_details.scss
@@ -81,16 +81,21 @@
         .another__image--box{
           height: 100px;
           width: 700px;
-          margin-bottom: 60px;
+          margin-bottom: 20px;
           padding-bottom: 20px;
           margin-top: 20px;
           display: flex;
-          .another__image{
-            height: 100%;
-            width: 220px;
-            margin-right: 20px;
+          justify-content: center;
+          &__item {
+            height: 100px;
+            width: 100px;
+            margin: 0 15px;
             display: flex;
             justify-content: center;
+            .item-subimage {
+              width:100%;
+              height: 100%;
+            }
           }
         }
       }
@@ -103,7 +108,6 @@
         .base__price{
           width: 400px;
           margin: auto;
-          padding-top: 40px;
           font-size: 45px;
           align-items: center;
           justify-content: center;

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
-  process resize_to_fit: [300, 300]
+  process resize_to_fit: [800, 800]
 
   # Choose what kind of storage to use for this uploader:
   if Rails.env.development? || Rails.env.test?

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -19,8 +19,8 @@
           = image_tag @item.images[0].image.url
         .another__image--box
           - @item.images.each do |image|
-            .another__image
-              = image_tag image.image.url
+            .another__image--box__item
+              = image_tag image.image.url, class:"item-subimage"
     .price__box
       .base__price
         = @item.price_introduce


### PR DESCRIPTION
# What
商品詳細ページの商品メイン画像の画質が荒かったためCarrierWaveのサイズを変更し
それに付随してサブ写真の表示も修正いたします。

# Why
商品出品の根幹であるメイン画像の画質が荒いと商品が見辛くなるため