### PR TITLE
item-purchase-soldlabel

### DIFF
--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -414,8 +414,10 @@
       height: 180px;
       margin-top: 20px;
       margin-left: 20px;
+      margin-right: 20px;
     }
       .item__base{
+        position: relative;
         display: block;
         color: #272727;
         padding-top: 20px;
@@ -448,7 +450,7 @@
             font-weight: 600;
           }
         }
-        .items-box_photo__reserved{
+        .items-box_photo__reserved:after{
           width: 0;
           height: 0;
           border-width: 120px 120px 0 0;

--- a/app/views/home/_item.html.haml
+++ b/app/views/home/_item.html.haml
@@ -5,14 +5,12 @@
     .item__base
       .item__post--image
         - if item.images.present?
-          =image_tag (item.images[0].image.url)
+          -if item.buyer_id.present? 
+            .items-box_photo__sold
+              .items-box_photo__sold__inner SOLD
+          = image_tag (item.images[0].image.url)
         -# - else
         -# = image_tag "no_image.png"
-      -if item.buyer_id.present? 
-        .items-box_photo__sold
-          .items-box_photo__sold__inner SOLD
-          .items-box_photo__reserved
-            .items-box_photo__reserved__inner Reserved
       
       .item__name--label
         =item.name


### PR DESCRIPTION
[What]
商品の購入ボタンが押された際に、SOLDラベルが表示されるようにする。

[Why]
対象の商品が売り切れていることがわからないと売れてしまっているものがまだ買えると誤解を生んだり、二重購入になってしまったりする恐れがあり、ユーザー間トラブルなどが起こる可能性があるため。