### PR TITLE
クレジットカード登録の単体テスト実装

### DIFF
--- a/spec/factories/credit.rb
+++ b/spec/factories/credit.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :credit do
+    user_id         {1}
+    card_id         {"car_eba824e741390e6508624e982fb2"}
+    customer_id     {"cus_43cdd3f7024692559c45a86c7f47"}
+  end
+end

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+describe Credit do
+  describe '#create' do
+    it "user_idがない場合は登録できないこと" do
+      credit = build(:credit, user_id: "")
+      credit.valid?
+      expect(credit.errors[:user_id]).to include("が入力されていません。")
+    end
+    it "customer_idがない場合は登録できないこと" do
+      credit = build(:credit, customer_id: "")
+      credit.valid?
+      expect(credit.errors[:customer_id]).to include("が入力されていません。")
+    end
+    it "card_idがない場合は登録できないこと" do
+      credit = build(:credit, card_id: "")
+      credit.valid?
+      expect(credit.errors[:card_id]).to include("が入力されていません。")
+    end
+  end
+end


### PR DESCRIPTION
# What
クレジットカード登録時の単体テストを実装します。

# Why
登録のバリデーションがしっかり行われているかサーバーサイドでも確認し
より正確性と安全性を確保するため。